### PR TITLE
Clarify assertion docs

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -1,6 +1,6 @@
-#' Assert that this is a nlmixr fit object
+#' Assert that this is a nlmixr2 fit object
 #'
-#' Will error without nlmixr fit object
+#' Will error without nlmixr2 fit object
 #'
 #' @param fit Fit object
 #' @return Nothing
@@ -16,14 +16,14 @@
 assertNlmixrFit <- function(fit) {
   .object <- as.character(substitute(fit))
   if (!inherits(fit, "nlmixr2FitCore")) {
-    stop("'", .object, "' needs to be a nlmixr fit object",
+    stop("'", .object, "' needs to be a nlmixr2 fit object",
          call.=FALSE)
   }
 }
 
-#' Assert that this is a nlmixr fit data object
+#' Assert that this is a nlmixr2 fit data object
 #'
-#' Will error without nlmixr fit data object
+#' Will error without nlmixr2 fit data object
 #'
 #' @param fit Fit object
 #' @return Nothing
@@ -39,11 +39,11 @@ assertNlmixrFit <- function(fit) {
 assertNlmixrFitData <- function(fit) {
   .object <- as.character(substitute(fit))
   if (!inherits(fit, "nlmixr2FitData")) {
-    stop("'", .object, "' needs to be a nlmixr fit object with data attached",
+    stop("'", .object, "' needs to be a nlmixr2 fit object with data attached",
          call.=FALSE)
   }
 }
-#' Assert a nlmixr object data frame row is compatible with what needs to be added
+#' Assert a nlmixr2 object data frame row is compatible with what needs to be added
 #'
 #' @param df Data frame to assert
 #' @param allowNa Allow NA data frame

--- a/man/assertNlmixrFit.Rd
+++ b/man/assertNlmixrFit.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/assert.R
 \name{assertNlmixrFit}
 \alias{assertNlmixrFit}
-\title{Assert that this is a nlmixr fit object}
+\title{Assert that this is a nlmixr2 fit object}
 \usage{
 assertNlmixrFit(fit)
 }
@@ -13,7 +13,7 @@ assertNlmixrFit(fit)
 Nothing
 }
 \description{
-Will error without nlmixr fit object
+Will error without nlmixr2 fit object
 }
 \examples{
 \dontrun{

--- a/man/assertNlmixrFitData.Rd
+++ b/man/assertNlmixrFitData.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/assert.R
 \name{assertNlmixrFitData}
 \alias{assertNlmixrFitData}
-\title{Assert that this is a nlmixr fit data object}
+\title{Assert that this is a nlmixr2 fit data object}
 \usage{
 assertNlmixrFitData(fit)
 }
@@ -13,7 +13,7 @@ assertNlmixrFitData(fit)
 Nothing
 }
 \description{
-Will error without nlmixr fit data object
+Will error without nlmixr2 fit data object
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
This clarifies some of the assertion documentation and warning to indicate nlmixr2 instead of nlmixr.