### PR TITLE
Remove patchwork library from vignettes to minimize dependencies

### DIFF
--- a/vignettes/addingCovariances.Rmd
+++ b/vignettes/addingCovariances.Rmd
@@ -82,12 +82,12 @@ plot(augPred(fit))
 ```{r}
 library(ggplot2)
 p1 <- vpcPlot(fit, show=list(obs_dv=TRUE));
-p1 <- p1+ ylab("Concentrations")
+p1 <- p1 + ylab("Concentrations")
 
 ## A prediction-corrected VPC
 p2 <- vpcPlot(fit, pred_corr = TRUE, show=list(obs_dv=TRUE))
-p2 <- p2+ ylab("Prediction-Corrected Concentrations")
+p2 <- p2 + ylab("Prediction-Corrected Concentrations")
 
-library(patchwork)
-p1 / p2
+p1
+p2
 ```

--- a/vignettes/multiple-endpoints.Rmd
+++ b/vignettes/multiple-endpoints.Rmd
@@ -324,16 +324,16 @@ print(fit.TOS)
 plot(fit.TOS)
 
 
-v1s <- vpcPlot(fit.TOS, show=list(obs_dv=T), scales="free_y") +
+v1s <- vpcPlot(fit.TOS, show=list(obs_dv=TRUE), scales="free_y") +
   ylab("Warfarin Cp [mg/L] or PCA") +
   xlab("Time [h]")
 
-v2s <- vpcPlot(fit.TOS, show=list(obs_dv=T), pred_corr = TRUE) +
+v2s <- vpcPlot(fit.TOS, show=list(obs_dv=TRUE), pred_corr = TRUE) +
   ylab("Prediction Corrected Warfarin Cp [mg/L] or PCA") +
   xlab("Time [h]")
 
-library(patchwork)
-v1s / v2s
+v1s
+v2s
 ```
 
 ## FOCEi fits
@@ -350,13 +350,14 @@ fit.TOF <- nlmixr(pk.turnover.emax3, warfarin, "focei", control=list(print=0),
 print(fit.TOF)
 plot(fit.TOF)
 
-v1f <- vpcPlot(fit.TOF, show=list(obs_dv=T), scales="free_y") +
+v1f <- vpcPlot(fit.TOF, show=list(obs_dv=TRUE), scales="free_y") +
   ylab("Warfarin Cp [mg/L] or PCA") +
   xlab("Time [h]")
 
-v2f <- vpcPlot(fit.TOF, show=list(obs_dv=T), pred_corr = TRUE) +
+v2f <- vpcPlot(fit.TOF, show=list(obs_dv=TRUE), pred_corr = TRUE) +
   ylab("Prediction Corrected Warfarin Cp [mg/L] or PCA") +
   xlab("Time [h]")
 
-v1f / v2f
+v1f
+v2f
 ```

--- a/vignettes/phenobarbitol.Rmd
+++ b/vignettes/phenobarbitol.Rmd
@@ -73,12 +73,12 @@ plot(augPred(fit))
 ```{r}
 library(ggplot2)
 p1 <- vpcPlot(fit, show=list(obs_dv=TRUE));
-p1 <- p1+ ylab("Concentrations")
+p1 <- p1 + ylab("Concentrations")
 
 ## A prediction-corrected VPC
 p2 <- vpcPlot(fit, pred_corr = TRUE, show=list(obs_dv=TRUE))
-p2 <- p2+ ylab("Prediction-Corrected Concentrations")
+p2 <- p2 + ylab("Prediction-Corrected Concentrations")
 
-library(patchwork)
-p1 / p2
+p1
+p2
 ```


### PR DESCRIPTION
While building the vignettes for testing, the patchwork library was required.  I removed it because the overall impact seemed small for the desire of combined plots.  If patchwork is preferred, then it should be added to the "suggests" in the DESCRIPTION file.

There are a few additional code-formatting tweaks in here, too.