### PR TITLE
Standardize reexports to work the same across systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ inst/doc
 docs
 /doc/
 /Meta/
+.Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: Fit and compare nonlinear mixed-effects models in differential
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Imports: 
     nlmixr2est,
     nlmixr2extra,

--- a/R/hardReexports.R
+++ b/R/hardReexports.R
@@ -249,5 +249,3 @@ covarSearchAuto <- function(fit, varsVec, covarsVec, pVal = list(fwd = 0.05,
 bootplot <- function(x, ...) {
     nlmixr2extra::bootplot(x = x, ...)
 }
-
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,22 +18,27 @@
   }
   .formalArgs <- paste(.formalArgs, collapse=", ")
   .newFun <- strsplit(fun, "::")[[1]][2]
+  .has3text <- NULL
   if (.has3) {
-    return(paste(c(paste0("#' @inherit ", fun),
-                   paste0("#' @param ... Additional arguments passed to [", fun, "()]."),
-                   "#' @export",
-                   deparse(str2lang(paste(c(paste0(.newFun, " <- ", paste(.args, collapse="\n"), " {"),
-                                            paste0(fun, "(", .formalArgs, ")"),
-                                            "}"), collapse="\n")))
-                   ),
-                   collapse="\n"))
+    .has3text <- paste0("#' @param ... Additional arguments passed to [", fun, "()].")
   }
-  paste(c(paste0("#' @inherit ", fun),
-          "#' @export",
-          deparse(str2lang(paste(c(paste0(.newFun, " <- ", paste(.args, collapse="\n"), " {"),
-                  paste0(fun, "(", .formalArgs, ")"),
-                  "}"), collapse="\n")))
-          ), collapse="\n")
+  paste(
+    c(paste("#' @inherit", fun),
+      .has3text,
+      "#' @export",
+      trimws(
+        deparse(str2lang(paste0(
+          c(paste0(.newFun, " <- ", paste0(.args, collapse="\n"), " {"),
+            paste0(fun, "(", .formalArgs, ")"),
+            "}"
+          ),
+          collapse="\n"
+        ))),
+        which = "right"
+      )
+    ),
+    collapse="\n"
+  )
 }
 
 .genSoftReExport <- function(fun, alias=NULL) {
@@ -41,17 +46,18 @@
   .pkg <- .newFun[1]
   .fun <- .newFun[2]
   if (is.na(.fun)) return("")
+  .aliasText <- NULL
   if (!is.null(alias)) {
-    .fun2 <- strsplit(alias, "::")[[1]][2]
-    paste(c(paste0("#' @importFrom ", .pkg, " ", .fun),
-            paste0("#' @rdname ", .fun2),
-            "#' @export",
-            fun), collapse="\n")
-  } else {
-    paste(c(paste0("#' @importFrom ", .pkg, " ", .fun),
-            "#' @export",
-            fun), collapse="\n")
+    .aliasText <- paste0("#' @rdname ", .fun2)
   }
+  paste(
+    c(paste("#' @importFrom", .pkg, .fun),
+      .aliasText,
+      "#' @export",
+      fun
+    ),
+    collapse="\n"
+  )
 }
 
 .genReexports <- function(soft=c("rxode2::rxode2",


### PR DESCRIPTION
When I was looking into some of the reexports, I found that my system generated them a bit differently than what was in git.  I've updated the code to both only have a single path to a return value (simplifying out some of the complexity around `...` arguments) and to ensure that it generates the same as the github version on Windows 11 with R 4.2.1.