### PR TITLE
docs(vae): how omega is updated, and what it changes for covariate selection

### DIFF
--- a/vignettes/articles/vaeNeonatal.Rmd
+++ b/vignettes/articles/vaeNeonatal.Rmd
@@ -554,7 +554,13 @@ diagonal: the covariate regression whitens dimension `k` by the scalar
   0.75, the `saemControl()` default) of the EM phase only the variances move;
   the correlations are estimated afterwards. This is `saem`'s `nb_correl` rule
   and it exists for the same reason -- correlations estimated before the
-  variances have settled are noise that the later iterations must undo.
+  variances have settled are noise that the later iterations must undo. Note the
+  fraction is of the **EM phase** (`min(gammaIter, iters)`), not of the whole
+  run, which is what makes it safe: the gain is 1 for `it <= gammaIter`, so the
+  correlations are released while the gain is still 1 and are estimable the
+  moment they are unfrozen. (`est = "emvi"` has no comparable unit-gain phase,
+  so it has to restart the off-diagonal gain at release instead -- omitting that
+  is not a theoretical concern, it recovered `rho = 0.16` against a true 0.75.)
 - **The covariate regression is a GLS in the full `Omega`.** Per-dimension
   whitening by `1/sqrt(omega_k)` is the correct metric only when `Omega` is
   diagonal; with a block, residuals across dimensions are correlated and that

--- a/vignettes/articles/vaeNeonatal.Rmd
+++ b/vignettes/articles/vaeNeonatal.Rmd
@@ -395,6 +395,7 @@ it.
 | Parameter transforms | `log`, `logit`, `probit`, identity (the standard `nlmixr2` set) | No: `log` only (`h = exp`) |
 | Bounds | `lower`/`upper` on a parameter are enforced by clamping the M-step estimate to the active bound | No |
 | Fixed parameters | Fixed structural `theta` (via `literalFix`), fixed `omega`, and fixed residual parameters are respected and excluded from estimation | No |
+| Correlated random effects | A declared block `eta.cl + eta.v ~ c(0.1, 0.01, 0.1)` has its off-diagonals estimated, held at zero for the first `perNoCor` of the run so the variances settle first (saem's rule). A `fixed()` covariance is honored throughout. See [Correlated random effects](#correlated-random-effects-omega-off-diagonals) | No: diagonal `omega` only |
 | Covariate selection | Exact, dependency-free branch-and-bound over subsets; search order configurable with `vaeControl(bnbStrategy=)` | Yes, but via a commercial MIQP solver (`cvxpy` + GUROBI) |
 | Multiple endpoints | Supported through the standard multiple-endpoint machinery | No: single endpoint |
 | Post-fit object | Full `nlmixr2FitData`: objective function, standard errors (`covMethod = "analytic"/"r,s"/...`), EBEs, CWRES/NPDE residuals, VPC, tables | No: prints and plots only |
@@ -493,12 +494,23 @@ and both solve the **same L0 objective per latent dimension**,
   means of `mu`, `mu mu'`, `sum L L'`, and the residual sum of squares) and
   derives `z_pop`, `omega`, `a` from the smoothed statistics -- the classic
   Kuhn-Lavielle scheme.
-- `nlmixr2` regresses the **current** iteration's posterior means directly and
-  then EMA-smooths the resulting **estimates** (`omega`, `a`; the covariate
-  intercept is taken from the fit).
+- `nlmixr2` can do either, and `vaeControl(omegaUpdate=)` chooses. The default
+  `"suffStat"` follows the reference: `omega` is built from the EMA sufficient
+  statistics and assigned outright. `"blend"` is the historic `nlmixr2` path,
+  regressing the **current** iteration's posterior means and then EMA-smoothing
+  the resulting **estimate** -- so it is smoothed twice.
 
 Both converge to the same stationary point but with different per-iteration
-trajectories. For covariate selection the reference uses a commercial **MIQP**
+trajectories. In fact they are the *same* update while the gain is 1, which it is
+for the whole burn-in and EM phase: assigning a value and blending it in with
+weight 1 are the same operation. They diverge only once `gammaIter` starts
+decaying the gain, so a short run at default settings shows no difference between
+them at all (measured: agreement to ~1e-13, separating to ~1e-5 once the gain
+decays).
+
+The residual error estimate is still EMA-smoothed on the standard-deviation
+scale, where the reference smooths the residual sum of squares and takes the root
+afterwards -- a known remaining difference, called out in `?vaeControl`. For covariate selection the reference uses a commercial **MIQP**
 (binary indicators, big-M constraints); `nlmixr2` uses an **exact
 branch-and-bound** with an admissible RSS lower-bound prune -- provably the same
 selected subset, no GUROBI license, and a configurable search order.
@@ -557,6 +569,40 @@ diagonal: the covariate regression whitens dimension `k` by the scalar
   coordinate descent over dimensions. For a diagonal `Omega`, `c_ik = 0` and
   `1/P_kk = omega_k`, recovering the reference expression unchanged.
 
+### What this changes for covariate selection
+
+The GLS metric is not only a scoring detail -- it can change **which covariates
+are selected**, because the L0 objective it feeds is the thing being minimized
+over subsets.
+
+Concretely, with a declared block the response dimension `k` is regressed on is
+no longer the raw residual but the residual plus an offset carrying the *other*
+dimensions' information, and the penalty is compared against the conditional
+variance `1/P_kk` rather than the marginal `omega_k`. Two consequences:
+
+- A covariate that looks uninformative for `eta.cl` on its own can become
+  worth its penalty once `eta.v`'s correlated residual is accounted for, and
+  vice versa. The stronger the correlation, the larger the divergence; at
+  `rho = 0` the offset vanishes, `1/P_kk = omega_k`, and the selected subset is
+  identical to the diagonal case by construction.
+- Because `1/P_kk <= omega_k` always (conditioning cannot increase variance --
+  the Schur-complement result), the penalty is weighed against a smaller
+  denominator, so a correlated block is in general *more* willing to retain a
+  covariate than the same model fitted with the correlation ignored. The gap is
+  not marginal at realistic correlations: at `rho = 0.75` the conditional
+  variance is 0.44 times the marginal one.
+
+One implementation point worth stating, since getting it wrong would be invisible
+in the output: when `covSelectMethod` uses `L0Learn` to **propose** candidate
+supports, the proposals are generated from the same GLS-adjusted response the
+exact search then scores. Proposing under the diagonal metric and scoring under
+the GLS one would quietly bias the candidate pool -- the proposal step would be
+answering a different question than the selection step.
+
+This is also the reason the correlated-omega work touches covariate selection at
+all. The two are usually independent knobs; here the covariance structure enters
+the selection objective directly.
+
 A diagonal model is therefore unaffected in every respect; the machinery only
 engages when the model declares a block. `est = "emvi"` gained the same
 treatment at the same time -- notably, with `viFamily = "fullRank"` the
@@ -591,19 +637,18 @@ from the EMA statistics while estimating the off-diagonal from raw moments would
 build one block out of two different estimators, and the result need not even be
 positive definite.
 
-Two consequences worth knowing:
+(As noted under [M-step](#m-step-same-idea-different-smoothing-point), the two
+`omegaUpdate` paths are the same update while the gain is 1, so they only differ
+in the smoothing tail.)
 
-* The two `omegaUpdate` paths **coincide while the gain is 1**, which it is for
-  the whole burn-in and until `gammaIter` starts decaying it -- assignment and
-  an EMA with weight 1 are the same operation. On short runs at default settings
-  they agree to floating-point noise (~1e-13); they separate only in the decay
-  phase, where the measured difference on a two-eta test model is ~1e-5.
-* `mStepObjective` does **not** enter the omega update at all. It selects what
-  the non-mu *theta* M-step is scored against (the full FOCEi outer objective, or
-  the reference's plain ELBO) and gates `nonMuTheta = "grad"`. Omega has a
-  closed-form EM update from the variational posterior either way, so the outer
-  objective only matters for the parameters that have no closed form. An
-  ELBO-only fit and an outer-objective fit use the same omega machinery.
+One more thing worth stating because it is natural to assume otherwise:
+**`mStepObjective` does not enter the omega update at all.** It selects what the
+non-mu *theta* M-step is scored against (the full FOCEi outer objective, or the
+reference's plain ELBO) and gates `nonMuTheta = "grad"`. Omega has a closed-form
+EM update from the variational posterior either way, so the outer objective only
+matters for the parameters that have no closed form. An ELBO-only fit and an
+outer-objective fit use identical omega machinery -- the branch above is chosen
+by `covariateSelection`, and the estimator within it by `omegaUpdate`.
 
 ## The regressor -- no counterpart in the reference
 


### PR DESCRIPTION
**Stacked on #401** -- base is `docs/vae-omega-offdiag`, so merge that first.
Documentation only. One commit.

Companion to nlmixr2est#825, which does the same for the reference docs
(`?vaeControl`, `?emviControl`).

## Why

The VAE article described the correlated-`omega` work without saying which omega
M-step it attaches to -- and there are two. One nearby section had also gone
stale.

## What changed

**Corrects the M-step comparison.** It said `nlmixr2` regresses the current
iteration's posterior means and EMA-smooths the resulting *estimates*, in
contrast to the reference's sufficient statistics. That is now only the
`"blend"` path: `vaeControl(omegaUpdate = "suffStat")` is the **default** and
follows the reference.

**Says which of the two omega M-steps runs.** The branch is chosen by
`covariateSelection`, not by the objective; within the covariate branch
`omegaUpdate=` picks the estimator; the plain closed-form branch has no switch.
A declared block's off-diagonals always follow whichever estimator that branch's
diagonal used -- taking the two halves of one block from different estimators
need not even give a positive-definite result.

**Adds what the GLS metric changes for covariate selection.** The section
derived the offset response and conditional variance but never drew the
consequence: they feed the L0 objective, so the *selected subset itself* can
differ from the diagonal case. Since `1/P_kk <= omega_k` always (Schur
complement), a correlated block is more willing to retain a covariate -- and the
gap is not marginal, at `rho = 0.75` the conditional variance is 0.44x the
marginal. I checked the inequality numerically over 2000 random SPD blocks (no
counterexamples) rather than asserting it.

It also records that the `L0Learn` **proposal** step scores on the same
GLS-adjusted response as the exact search. Proposing under the diagonal metric
and selecting under the GLS one would bias the candidate pool with nothing in the
output to show for it.

**Adds correlated random effects to the supported-features table.**

## Two things stated plainly because they are easy to assume wrongly

- The two `omegaUpdate` paths are the **same update while the gain is 1**, which
  it is throughout burn-in and the EM phase. A short run at default
  `gammaIter = 250` shows no difference at all (~1e-13), separating (~1e-5) only
  once the gain decays. Anyone A/B-testing the option at defaults would
  reasonably conclude it does nothing.
- **`mStepObjective` does not enter the omega update.** It scores the non-mu
  theta M-step. An ELBO-only fit and an outer-objective fit use identical omega
  machinery -- verified across all four `mStepObjective` x `omegaUpdate`
  combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMZpj6ywLmjmB9p3fzMpoQ
