### PR TITLE
chore: gitignore R build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ docs
 /doc/
 /Meta/
 .Rhistory
+
+# Build artifacts (R CMD build/INSTALL/check output)
+*.Rcheck/
+*.tar.gz
+*.tgz
+.RData
+.Rhistory
+vignettes/*_files/


### PR DESCRIPTION
These are produced by R CMD INSTALL/build/check on a normal developer machine and were showing up as untracked in every status, which also blocks 'git pull --ff-only' on the default branch.