### PR TITLE
docs: stop knitr parsing prose as inline R in the VAE article

### DIFF
--- a/vignettes/articles/vaeNeonatal.Rmd
+++ b/vignettes/articles/vaeNeonatal.Rmd
@@ -729,7 +729,7 @@ against 87.4).
 
 One implementation note worth stating, since it is a trap: a residual scale
 parameter is floored strictly above zero. The likelihood floors a zero variance
-(`r == 0` becomes `r = 1`) to stay finite, which makes a collapsed residual look
+(a variance `r` of 0 becomes `r` = 1) to stay finite, which makes a collapsed residual look
 *attractive* to an optimizer rather than forbidden -- a Box-Cox fit converged to
 `add.err = 0` before that bound existed, and still beat the closed form on
 objective value while doing it.


### PR DESCRIPTION
## Problem

`vignettes/articles/vaeNeonatal.Rmd` failed to render:

```
Error: Failed to parse the inline R code: `r == 0`
Reason: <text>:1:1: unexpected '=='
```

The prose reads ``(`r == 0` becomes `r = 1`)``. A backtick followed by `r ` is knitr's inline-R marker, so both of those are taken as code to evaluate rather than as the variable name `r`.

## Fix

Reword so only the variable name is inside backticks.

Verified: the article renders, and the sentence comes out as intended (`a variance <code>r</code> of 0 becomes <code>r</code> = 1`).

## Note on the other two article failures

The `broom` and `xgxr-nlmixr-ggpmx` articles were failing too, but for causes outside this repo — fixed separately in:

- nlmixr2/rxode2#1181 — `rxCompile()` generated C from the parser's global last-parsed model rather than the model handed to it, so a restored SAEM fit came back solving a different model ("The following parameter(s) are required for solving: eta.v, eta.cl").
- nlmixr2/nlmixr2save#7 — a restored fit's `ID` came back an integer instead of a factor, so `ggPMX::pmx_nlmixr()` failed in a data.table join.

With all three in place, `vignettes/precompute.R` renders all 10 cached articles with 0 failures, and every other vignette/article renders except `articles/advi-variational-inference.Rmd`, which is unrelated and pre-existing: it needs `est = "advi"` / `adviControl()`, which do not exist in nlmixr2est 7.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)