### PR TITLE
docs: regenerate with roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,4 @@ Suggests:
     devtools
 BugReports: https://github.com/nlmixr2/nlmixr2/issues/
 URL: https://nlmixr2.org/, https://github.com/nlmixr2/nlmixr2/
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0


### PR DESCRIPTION
Regenerated the package documentation with roxygen2 8.1.0 (was 8.0.0).

0 files under man/ changed.  No R source and no exported behavior changed.